### PR TITLE
Set XDG_SESSION_TYPE for wayland too

### DIFF
--- a/etc/systemd/user/gnome-wayland-nested@.service
+++ b/etc/systemd/user/gnome-wayland-nested@.service
@@ -4,6 +4,7 @@ Description=Run nested Wayland gnome session for display %I
 [Service]
 Environment="DISPLAY=%I"
 Environment="MUTTER_DEBUG_DUMMY_MODE_SPECS=1920x1080@30.0"
+Environment="XDG_SESSION_TYPE=wayland"
 ExecStart=gnome-shell --nested --wayland --no-x11
 
 [Install]


### PR DESCRIPTION
An extension I'm trying to use this against expects the XDG_SESSION_TYPE environment variable to be set. AFAIK that's the case on a normal system, and you have it for the Xorg service so I expect this is fine to add for wayland too.

Thanks for the project and blog posts, it's good stuff!